### PR TITLE
Adds extension method to allow for adding empty subtopic delegate

### DIFF
--- a/Libraries/PromptlyBot/ConversationTopic.cs
+++ b/Libraries/PromptlyBot/ConversationTopic.cs
@@ -17,6 +17,13 @@ namespace PromptlyBot
 
     public delegate ITopic CreateSubTopicDelegate(params object[] args);
 
+    public static class CreateSubTopicDictionaryExtensions
+    {
+        public static void Add(this Dictionary<string, CreateSubTopicDelegate> subtopics, string key, Func<ITopic> value)
+            => subtopics.Add(key, _ => value());
+    }
+        
+
     public abstract class ConversationTopic<TState> : Topic<TState> where TState : ConversationTopicState, new()
     {
         private readonly ConversationTopicFluentInterface _set;

--- a/Samples/AlarmBot/Topics/RootTopic.cs
+++ b/Samples/AlarmBot/Topics/RootTopic.cs
@@ -24,7 +24,7 @@ namespace AlarmBot.Topics
                 context.State.UserProperties[USER_STATE_ALARMS] = new List<Alarm>();
             }
 
-            this.SubTopics.Add(ADD_ALARM_TOPIC, (object[] args) =>
+            this.SubTopics.Add(ADD_ALARM_TOPIC, () =>
             {
                 var addAlarmTopic = new AddAlarmTopic();
 


### PR DESCRIPTION
Adds an extension method to `Dictionary<string, CreateSubTopicDelegate>` that allows callers to specify an empty `Func<ITopic>` which will be wrapped in a `CreateSubTopicDelegate` that simply eats the incoming args and invokes the underlying `Func<ITopic>`.